### PR TITLE
Removed netstandard2.0 target framework

### DIFF
--- a/src/OpenTelemetry.AutoInstrumentation.Digma/OpenTelemetry.AutoInstrumentation.Digma.csproj
+++ b/src/OpenTelemetry.AutoInstrumentation.Digma/OpenTelemetry.AutoInstrumentation.Digma.csproj
@@ -2,7 +2,7 @@
 
     <PropertyGroup>
         <IsPackable>true</IsPackable>
-        <TargetFrameworks>netstandard2.0;net47;net5.0;net6.0;net7.0;net8.0;net9.0</TargetFrameworks>
+        <TargetFrameworks>net47;net5.0;net6.0;net7.0;net8.0;net9.0</TargetFrameworks>
         <LangVersion>10</LangVersion>
         <PackageId>OpenTel.AutoInstrumentation.Digma</PackageId>
         <RootNamespace>OpenTelemetry.AutoInstrumentation.Digma</RootNamespace>

--- a/src/OpenTelemetry.AutoInstrumentation.Digma/publish_all.sh
+++ b/src/OpenTelemetry.AutoInstrumentation.Digma/publish_all.sh
@@ -8,4 +8,6 @@ for tfm in "${targets[@]}"; do
     dotnet publish -c Release -f $tfm -o "bin/Publish/$tfm"
 done
 
- zip -r bin/Publish/OpenTelemetry.AutoInstrumentation.Digma.zip bin/Publish
+cd bin/Publish/
+zip -r OpenTelemetry.AutoInstrumentation.Digma.zip .
+cd ../../


### PR DESCRIPTION
Because there is no Lib.Harmony implementation for netstandard2.0, only thin placeholder.